### PR TITLE
Adding movies.showings API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ api.lineups.search ("Blue")
     - `api.stations`
         - `.details`
         - `.airings`
+- Movies
+    - `api.movies`
+        - `.showings`
 
 ## TODO:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ api.lineups.search ("Blue")
 
 ## Implemented APIs
 
-- Prorgrams
+- Programs
     - `api.programs`
         - `.search(query, params)`
 - Lineups

--- a/lib/gracenote.js
+++ b/lib/gracenote.js
@@ -13,6 +13,7 @@ var Gracenote = function(api_key){
     self.host =  "https://data.tmsapi.com/v1.1";
     self.api_key = api_key;
     self.date_format = 'YYYY-MM-DDTHH:mmZ';
+    self.date_only_format = 'YYYY-MM-DD';
     self.defaultLineupId = 'USA-IL53277-X';
     self.defaultStationId = '10359';
 
@@ -185,6 +186,22 @@ var Gracenote = function(api_key){
 
                 return self._get( url, payload );
             }
+
+        },
+
+        movies: {
+
+          showings: function( params ) {
+            var url = 'movies/showings';
+
+            var defaults = {
+              startDate: moment().format(self.date_only_format)
+            };
+
+            var payload = extend(defaults, params);
+
+            return self._get(url, payload);
+          }
 
         }
     };


### PR DESCRIPTION
Adds support for the local showtimes public plan method: http://developer.tmsapi.com/docs/data_v1_1/movies/Movies_playing_in_local_theatres